### PR TITLE
Update backup.sh

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -20,6 +20,8 @@
 #                                                                                                                             #
 # Property of Red Hat, all rights reserved.                                                                                   #
 # https://github.com/AhmedAbdala/OCP-useful/blob/main/backup.sh                                                               #
+# To directly download script: curl https://raw.githubusercontent.com/AhmedAbdala/OCP-useful/main/backup.sh                   #
+#                                                                                                                             #
 # Maintainer: <azaky@redhat.com>                                                                                              #
 #             <amzaky@linux.com>                                                                                              #
 #                                                                                                                             #
@@ -32,6 +34,35 @@ echo "Welcome! to the OCP backup script!"
 echo "---------------------------------------------"
 echo -e "\n \n"
 
+# Gathering environment facts
+
+# Checking whether it is a (dis)connected cluster
+ping www.google.com -c2 > /dev/null
+if [[ $? -eq 0 ]]
+then
+    connected="true"
+    echo '====>  This is a connected cluster or bastion is connected'
+else
+    disconnected="true"
+    echo '====>  This is a disconnected cluster or bastion is disconnected'
+fi
+
+# Installing bzip2 package if needed on a connected bastion
+bzipInstalled=$(rpm -qa bzip2)
+if [[ -z $bzipInstalled && $connected == true ]]
+then
+    echo '====>  bzip2 package not installed, attempting to install needed bzip2 package'
+    sudo dnf -y install bzip2
+fi
+if [[ -n $bzipInstalled ]]
+then
+    echo "====>  bzip2 package installed, no further action needed"
+fi
+
+if [[ -z $bzipInstalled && $disconnected == true ]]
+then
+    echo '====>  "This is a diconnected bastion, bzip2 package not installed & can not be installed'
+fi
 
 # Make sure you're logged in to the OCP cluster
 # If not, ask for username and password
@@ -39,24 +70,24 @@ echo -e "\n \n"
 oc whoami &> /dev/null
 
 if [[ $? -eq 0 ]]
-	then
-		echo 'you are already logged in to the cluster'
-	else
-  	echo “What is the username to login to the cluster? ” 
-  	read username 
-	  echo “please enter your password ” 
-	  read password 
-	  echo '** Trying to login to the cluster as admin! **' 
-	  eval oc login -u ${username} -p ${password} ${ocpServer} > /dev/null
-	  if [[ $? -eq 0 ]]
-		 then
-	           echo '====> Login to OCP Cluster successful'
-		   echo -e "\n \n"
-		   ocpServer=$(oc whoami --show-server)
-		  else
-		    echo '====> Could not login to the cluster, exiting now'
-		    exit 300	
-	  fi
+    then
+        echo '====>  you are already logged in to the cluster'
+    else
+    echo “What is the username to login to the cluster? ” 
+    read username 
+    echo “please enter your password ” 
+    read password 
+    echo '** Trying to login to the cluster as admin! **' 
+    eval oc login -u ${username} -p ${password} ${ocpServer} > /dev/null
+    if [[ $? -eq 0 ]]
+        then
+            echo '====> Login to OCP Cluster successful'
+        echo -e "\n \n"
+        ocpServer=$(oc whoami --show-server)
+        else
+            echo '====> Could not login to the cluster, exiting now'
+            exit 300	
+    fi
 fi
 
 # Check the health of the nodes
@@ -111,7 +142,7 @@ echo
 
 echo '** Starting a new debug pod **'
 # Start a clean new debug pod and keep it running in the background
- 
+
 echo <<< $(oc debug node/$(oc get nodes | grep master | grep -w Ready | awk '{print $1}' | head -n1) &>/dev/null) &
 
 # back-off to make sure the debug pod is running
@@ -180,10 +211,21 @@ echo
 echo '** tar the local /tmp/host directory **'
 cd /tmp
 rm -rf host*.gz
-tar -cjf host_$(date +%F-%H-%M-%S).tar.gz host
-tarball=$(ls -lth | grep host*.gz| awk {'print $9'})
-echo -e " ====> tarball $tarball saved under local /tmp directory"
-echo
+if [[ connected == true ]]
+then 
+    tar -cjvf host_$(date +%F-%H-%M-%S).tar.gz host
+    tarball=$(ls -lth | grep host*.gz| awk {'print $9'})
+    echo -e " ====> tarball $tarball saved under local /tmp directory"
+    echo
+fi
+
+if [[ disconnected == true ]]
+then
+    tar -cvf host_$(date +%F-%H-%M-%S).tar host
+    tarball=$(ls -lth | grep host*.tar| awk {'print $9'})
+    echo -e " ====> tarball $tarball saved under local /tmp directory"
+    echo
+fi 
 
 echo '** Removing /tmp/host directory **'
 rm -rf /tmp/host


### PR DESCRIPTION
Added checks for (disc)/connected or restricted environments. Install bzip2 package if it is missing in a connected environment. In a disconnected environment the bzip2 package will not be installed and instead the generated backup on the local machine will be in a tar format. If the bzip package is installed on the local machine then the generated tar achive will be further compressed using bzip.